### PR TITLE
Alloc crate is not used, so no need to import it!

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-extern crate alloc;
 
 mod bool_trie;
 mod tables;


### PR DESCRIPTION
Could theoretically have consequences if upstreamed, since it would allow compilation without the alloc crate. Probably has no effect for the RustPython project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal dependency handling by removing an obsolete declaration, aligning with current compiler capabilities. No changes to functionality or public API.
* **Chores**
  * Build cleanup to reduce maintenance overhead and improve compatibility with contemporary toolchains.
* **No User-Visible Changes**
  * This update does not affect features, behavior, or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->